### PR TITLE
Added a 'flip' prop to make the cards flip without any touch

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -105,6 +105,7 @@ export default class FlipCard extends Component {
   }
 }
 FlipCard.propTypes = {
+  flip: PropTypes.bool,
   flipped: PropTypes.bool,
   friction: PropTypes.number,
   flipHorizontal: PropTypes.bool,

--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -19,6 +19,11 @@ export default class FlipCard extends Component {
       rotate: new Animated.Value(Number(props.flipped))
     }
   }
+  componentWillReceiveProps (nextProps) {
+      if (!this.props.clickable && this.props.flip !== nextProps.flip) {
+          this._toggleCard();
+      }
+  }
   _toggleCard () {
     this.setState({isFlipping: true})
     this._animation(!this.state.isFlipped)
@@ -80,7 +85,11 @@ export default class FlipCard extends Component {
     }
     return (
       <TouchableWithoutFeedback
-        onPress={this.props.clickable && this._toggleCard.bind(this)}
+        onPress={() => {
+            if (this.props.clickable) {
+                this._toggleCard();
+            }
+        }}
       >
         <Animated.View
           {...this.props}
@@ -173,4 +182,3 @@ Back.propTypes = {
   children (props, propName, componentName) {
   }
 }
-


### PR DESCRIPTION
When `clickable` prop is false, the user can still flip the card using the new `flip` prop and changing it.
It's useful when you want another component or gesture to make the cards flip.
