### PR TITLE
Clear measure timeout if unmounting

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -47,8 +47,11 @@ export default class FlipCard extends Component {
   }
 
   componentDidMount () {
+    this.measureOtherSideTimeout = setTimeout(this.measureOtherSide.bind(this), 8);
+  }
 
-    setTimeout(this.measureOtherSide.bind(this), 8)
+  componentWillUnmount() {
+    clearTimeout(this.measureOtherSideTimeout);
   }
 
   measureOtherSide () {


### PR DESCRIPTION
I have an edge case where a measurement is happening right after a component unmounts. Let me know if I need to make any revisions.
