### PR TITLE
Changing style to PropTypes.style to work with ReactNativeWeb

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -180,7 +180,7 @@ FlipCard.propTypes = {
   onFlipped: PropTypes.func,
   alignHeight: PropTypes.bool,
   alignWidth: PropTypes.bool,
-  style: View.propTypes.style,
+  style: PropTypes.style,
   children (props, propName, componentName) {
     const prop = props[propName]
     if (React.Children.count(prop) !== 2) {


### PR DESCRIPTION
By changing to PropTypes.style this component is able to work with ReactNativeWeb and build with WebPack - it also still maintains the necessary prop check/validation.