### PR TITLE
Fix flash of back on card load while not using align options

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -8,8 +8,12 @@ import S from './Style.js'
 export default class FlipCard extends Component {
   constructor (props) {
     super(props)
+
+    // set reversed boolean for detect other side size
+    const isFlipped = (this.props.alignHeight || this.props.alignWidth) ? !props.flip : props.flip;
+
     this.state = {
-      isFlipped: !props.flip, // set reversed boolean for detect other side size
+      isFlipped: isFlipped,
       isFlipping: false,
       rotate: new Animated.Value(Number(props.flip)),
       mesured: false, // the flag to check whether it is measured or not.
@@ -47,7 +51,9 @@ export default class FlipCard extends Component {
   }
 
   componentDidMount () {
-    this.measureOtherSideTimeout = setTimeout(this.measureOtherSide.bind(this), 8);
+    if (this.props.alignHeight || this.props.alignWidth) {
+      this.measureOtherSideTimeout = setTimeout(this.measureOtherSide.bind(this), 8);
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
The process of measuring the back in place causes a brief display of
the card back before the card front displays. Because this information
is only needed when using the alignHeight or alignWidth options, we
can avoid this display of the card's back when not using those options.

This commit checks whether the card is using alignHeight or alignWidth,
and if so measures the card back the same way it currently does, but if
not immediately shows the card front instead.

Test plan:

Used in an internal project, we tested loading a FlipCard and no
longer saw the blink showing the card's back when first rendering it.

Please let me know if I can be helpful talking about any of this, and thank you!