### PR TITLE
Fix card mirroring when flipped in RN 42.0+ 

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -227,10 +227,10 @@ export class Back extends Component {
   render () {
     var transform = []
     if (this.props.flipHorizontal) {
-      transform.push({skewY: '180deg'})
+      transform.push({scaleX: -1})
     }
     if (this.props.flipVertical) {
-      transform.push({skewX: '180deg'})
+      transform.push({scaleY: -1})
     }
 
     return (


### PR DESCRIPTION
I am just applying @boennemann's fix for issue #26. 
I have tested the diff in my application and my cards are no longer mirrored when flipped.