### PR TITLE
Removed not used refs and set useNativeDriver true

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -51,7 +51,8 @@ export default class FlipCard extends Component {
     Animated.spring(this.state.rotate,
      {
         toValue: Number(isFlipped),
-        friction: this.props.friction
+        friction: this.props.friction,
+        useNativeDriver: true
       }
     ).start((param) => {
       this.setState({isFlipping: false})
@@ -103,7 +104,6 @@ export default class FlipCard extends Component {
     if (this.state.isFlipped) {
       render_side = (
         <Back
-          ref='back'
           style={[ this.state.height > 0 && {height: this.state.height}, this.state.width > 0 && {width: this.state.width}]}
           flipHorizontal={this.props.flipHorizontal}
           flipVertical={this.props.flipVertical}
@@ -127,7 +127,6 @@ export default class FlipCard extends Component {
     } else {
       render_side = (
         <Face
-          ref='face'
           style={[ this.state.height > 0 && { height: this.state.height }, this.state.width > 0 && { width: this.state.width }]}
           onLayout={(event) => {
             var {x, y, width, height} = event.nativeEvent.layout;
@@ -167,7 +166,6 @@ export default class FlipCard extends Component {
           onPress={() => { this._toggleCard(); }}
         >
           <Animated.View
-            ref='animatedView'
             {...this.props}
             style={[
               S.flipCard,
@@ -262,7 +260,8 @@ export class Back extends Component {
     }
 
     return (
-      <View ref='back'style={[
+      <View
+      style={[
         S.back,
         this.props.style,
         {transform: transform}


### PR DESCRIPTION
The refs were not used, so can be removed. (I had to remove them, because of this bug: https://github.com/facebook/fresco/issues/1835)
useNativeDriver should make the animation use less resources