### PR TITLE
Huawei, Android 7  fix + Wrapped in Animated View Fix

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -50,7 +50,7 @@ export default class FlipCard extends Component {
      {
         toValue: Number(isFlipped),
         friction: this.props.friction,
-        useNativeDriver: true
+        useNativeDriver: this.props.useNativeDriver
       }
     ).start((param) => {
       this.setState({isFlipping: false})
@@ -105,6 +105,7 @@ export default class FlipCard extends Component {
           style={[ this.state.height > 0 && {height: this.state.height}, this.state.width > 0 && {width: this.state.width}]}
           flipHorizontal={this.props.flipHorizontal}
           flipVertical={this.props.flipVertical}
+		  perspective={this.props.perspective}
           onLayout={(event) => {
             var {x, y, width, height} = event.nativeEvent.layout
             var _update = Object.assign(this.state.back, {width: width, height: height})
@@ -204,6 +205,7 @@ FlipCard.propTypes = {
   onFlipStart: PropTypes.func,
   alignHeight: PropTypes.bool,
   alignWidth: PropTypes.bool,
+  useNativeDriver: PropTypes.bool,
   children (props, propName, componentName) {
     const prop = props[propName]
     if (React.Children.count(prop) !== 2) {
@@ -228,6 +230,7 @@ FlipCard.defaultProps = {
   onFlipStart: () => {},
   alignHeight: false,
   alignWidth: false,
+  useNativeDriver: true,
 }
 
 
@@ -254,9 +257,11 @@ export class Back extends Component {
     var transform = []
     if (this.props.flipHorizontal) {
       transform.push({scaleX: -1})
+	  transform.push({perspective: this.props.perspective})
     }
     if (this.props.flipVertical) {
       transform.push({scaleY: -1})
+	  transform.push({perspective: this.props.perspective})
     }
 
     return (
@@ -275,12 +280,14 @@ export class Back extends Component {
 
 Back.defaultProps = {
   flipHorizontal: false,
-  flipVertical: true
+  flipVertical: true,
+  perspective: 1000,
 }
 
 Back.propTypes = {
   flipHorizontal: PropTypes.bool,
   flipVertical: PropTypes.bool,
+  perspective: PropTypes.number,
   children (props, propName, componentName) {
   }
 }


### PR DESCRIPTION
Fixes for issues:

#43 , Which turned out to probably be an error specifically for Huawei devices running Android 7. The fix was to push a perspective in the same transforms as the scales in Back. In the fix I use the perspective provided to the FlipCard.

#42 , I added a new prop to flipcard called useNativeDriver. It is set to true by default. When true, however, it seems to break the flipcard when it is provided an animated style, in my case while animating the margins of the style. Enabling the ability to set it to false solves this issue.

Hope this will help. I've tested it in my project and it seems to work fine.