### PR TITLE
Add a customAnimation props that can be used to customize the animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import FlipCard from 'react-native-flip-card'
 Customized
 ---
 ```
-<FlipCard 
+<FlipCard
   style={styles.card}
   friction={6}
   perspective={1000}
@@ -122,6 +122,14 @@ If you pass `true` to `alignWidth` param, the card keep width of bigger side.
 useNativeDriver(boolean) `Default:false`
 ---
 If you pass `true` to `useNativeDriver` param, the card animation will utilize the native driver.
+
+customAnimation(function) `Default:Animated.spring`
+---
+Customize the animation applied on the rotation angle. This function takes two arguments:
+ - `value`: the value to animate
+ - `toValue`: the final value at the end of the animation
+
+**Example:** for a 200ms linear animation, `customAnimation={(value, toValue) => Animated.timing(value, { toValue, duration: 200, useNativeDriver: true })}`
 
 Credits
 ===

--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -47,13 +47,16 @@ export default class FlipCard extends Component {
         this.timer = null
       }, 120)
     }
-    Animated.spring(this.state.rotate,
-     {
-        toValue: Number(isFlipped),
-        friction: this.props.friction,
-        useNativeDriver: this.props.useNativeDriver
-      }
-    ).start((param) => {
+    const animation = this.props.customAnimation
+      ? this.props.customAnimation(this.state.rotate, Number(isFlipped))
+      : Animated.spring(this.state.rotate,
+        {
+          toValue: Number(isFlipped),
+          friction: this.props.friction,
+          useNativeDriver: this.props.useNativeDriver
+        }
+      )
+    animation.start((param) => {
       this.setState({isFlipping: false})
       this.props.onFlipEnd(this.state.isFlipped)
     })
@@ -207,6 +210,7 @@ FlipCard.propTypes = {
   alignHeight: PropTypes.bool,
   alignWidth: PropTypes.bool,
   useNativeDriver: PropTypes.bool,
+  customAnimation: PropTypes.func,
   children (props, propName, componentName) {
     const prop = props[propName]
     if (React.Children.count(prop) !== 2) {


### PR DESCRIPTION
The FlipCard component currently uses a "spring" animation to animate the rotation angle. It is possible to change the friction value but that's all.

This commit adds a new "customAnimation" props that allows user to pass a function that returns the animation to use. It can be used to replace the "spring" animation by a "timing" animation for example, or to have even more control on the "spring" animation by changing the tension value.

Here is an example of usage:
<FlipCard
  ...
  customAnimation={(value, toValue) => Animated.timing(value, { toValue, duration: 500, useNativeDriver: true })}
>