### PR TITLE
add prop auth for style, remove border width property

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -8,11 +8,16 @@ import {
   TouchableOpacity,
   Animated,
   Platform
+  ViewPropTypes
 } from "react-native";
 
 import S from './Style.js'
 
 export default class FlipCard extends Component {
+  static propTypes = {
+    style: ViewPropTypes.style
+  }
+
   constructor (props) {
     super(props)
 
@@ -161,6 +166,7 @@ export default class FlipCard extends Component {
       }
         return (
         <TouchableOpacity
+          style={{flex:1}}
           testID={this.props.testID}
           activeOpacity={1}
           onPress={() => { this._toggleCard(); }}

--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -7,7 +7,7 @@ import {
   View,
   TouchableOpacity,
   Animated,
-  Platform
+  Platform,
   ViewPropTypes
 } from "react-native";
 

--- a/lib/Style.js
+++ b/lib/Style.js
@@ -4,7 +4,6 @@ import {StyleSheet} from 'react-native'
 export default StyleSheet.create({
   flipCard: {
     flex: 1,
-    borderWidth: 1
   },
 
   face: {


### PR DESCRIPTION
Using the style prop, this border can be implemented as needed.
Implementing on a use-case basis would seem to be a better practice than disabling these borders for every use. 

added authentication for the style prop