### PR TITLE
style property added twice removed.

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -170,7 +170,6 @@ export default class FlipCard extends Component {
           testID={this.props.testID}
           activeOpacity={1}
           onPress={() => { this._toggleCard(); }}
-          style={{flex: 1}}
         >
           <Animated.View
             {...this.props}


### PR DESCRIPTION
Because of the `style` prop added twice android release build was giving error "attempted to redefine property 'style' ". 

Hope that helps!