### PR TITLE
Remove double `style` key on TouchableOpacity. Fixes SyntaxError: Attempted to redefine property 'style'.

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -170,7 +170,6 @@ export default class FlipCard extends Component {
           testID={this.props.testID}
           activeOpacity={1}
           onPress={() => { this._toggleCard(); }}
-          style={{flex: 1}}
         >
           <Animated.View
             {...this.props}


### PR DESCRIPTION
This caused an Android-only crash by just importing the dependency (immediate runtime error) that for some reason doesn't include a stack-trace: SyntaxError: Attempted to redefine property 'style'.
This crash does not seem to occur on iOS devices but this dependency is a dependency of a dependency of my project so it was really annoying to track down. The least I could do is make this PR hoping it helps hours of debugging to others!

