### PR TITLE
issueMultipleStyleDefinedCrashInAndroid

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -170,7 +170,6 @@ export default class FlipCard extends Component {
           testID={this.props.testID}
           activeOpacity={1}
           onPress={() => { this._toggleCard(); }}
-          style={{flex: 1}}
         >
           <Animated.View
             {...this.props}


### PR DESCRIPTION
Multiple Style is Defined in render method. Due to that it is crashing android app.
Just Check style={{flex: 1}}