### PR TITLE
Prevent flickering when flipping in android

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -50,7 +50,7 @@ export default class FlipCard extends Component {
       this.timer = setTimeout(() => {
         this.setState({isFlipped: !this.state.isFlipped})
         this.timer = null
-      }, 120)
+      }, 30)
     }
     Animated.spring(this.state.rotate,
      {


### PR DESCRIPTION
The timeout to rotate the child views while flipping the card was taking too long and was causing a visible flicker. This PR should fix it.