### PR TITLE
Remove componentWillReceiveProps

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -35,8 +35,13 @@ export default class FlipCard extends Component {
       back: { width: 0, height: 0 }
     }
   }
-  componentWillReceiveProps (nextProps) {
-    if (this.state.isFlipped !== nextProps.flip) {
+  static getDerivedStateFromProps (nextProps, prevState) {
+    if (prevState.isFlipped !== nextProps.flip) {
+      return { flip: nextProps.flip }
+    } else return null
+  }
+  componentDidUpdate (prevProps) {
+    if (prevProps.flip !== this.props.flip) {
       this._toggleCard()
     }
   }


### PR DESCRIPTION
Removes deprecation warning

Solves #80 - Use of deprecated `componentWillReceiveProps`