### PR TITLE
add deprecated-react-native-prop-types

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -8,8 +8,8 @@ import {
   TouchableOpacity,
   Animated,
   Platform,
-  ViewPropTypes
 } from "react-native";
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 import S from './Style.js'
 


### PR DESCRIPTION
Adding missing dependency deprecated-react-native-prop-types