### PR TITLE
Use deprecate-react-native-prop-types

### DIFF
--- a/lib/FlipCard.js
+++ b/lib/FlipCard.js
@@ -8,8 +8,8 @@ import {
   TouchableOpacity,
   Animated,
   Platform,
-  ViewPropTypes
 } from "react-native";
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 import S from './Style.js'
 


### PR DESCRIPTION
Platforms affected
All

What does this PR do?
RN 0.68 has deprecated and will eventually remove ViewPropTypes (see post). This adds the deprecated-react-native-prop-types package and uses that instead.

What testing has been done on this change?
Local testing, to ensure the deprecation warning has been removed.